### PR TITLE
Removed leading empty lines

### DIFF
--- a/bin/transformer.py
+++ b/bin/transformer.py
@@ -66,6 +66,10 @@ class Page:
 
         # adding all text to main XML code
         export_string = BASE_PAGE.format(main_str)
+        
+        # Removing leading empty lines
+        export_string = export_string.strip("\n")
+        
         # saving to file
         with open(to_file, "w") as f:
             f.write(export_string)


### PR DESCRIPTION
For some reason with a leading empty line the draw.io website will use the files, but the draw.io Desktop app will show invalid file data.

Please be advised:
I am not a python dev so this might be a bad solution.

Some Trivia:

Thanks for your script. I was baffled last night when I again could not find a simple workflow to create a bunch of json data and then use the json data (or some conversion result of it) to build a diagram which I can then interactively manipulate.

I did not find any easy workflow for such a mundane task which is the starting point for many ideas/projects. Your script therefore saved me :)